### PR TITLE
Add shebang for the main source file

### DIFF
--- a/moonview.lua
+++ b/moonview.lua
@@ -1,3 +1,4 @@
+#!/usr/bin/lua
 --[[--
  @package   MoonView
  @filename  moonview.lua


### PR DESCRIPTION
This will allow the user to run `./moonview.lua` as an executable (if the user has lua installed and has the main file marked as an executable)